### PR TITLE
Fixing barracks spawning large groups of warriors

### DIFF
--- a/script/barracks.js
+++ b/script/barracks.js
@@ -46,8 +46,8 @@ class Barracks extends Building
 
     warriorDied()
     {
-        this.warriors--;
-        this.deployed--;
+        if(this.warriors > 0) this.warriors--;
+        if(this.deployed > 0) this.deployed--;
     }
 
     update()
@@ -64,5 +64,6 @@ class Barracks extends Building
         fill(255);
         textAlign(CENTER);
         text('BARRACKS', this.posX, this.posY - 30);
+        text(`Warriors ${this.warriors.toFixed()} ; Deployed ${this.deployed}`, this.posX, this.posY+30)
     }
 }

--- a/script/villager.js
+++ b/script/villager.js
@@ -1,3 +1,7 @@
+const VILLAGER_STATUS_ALIVE = 1;
+const VILLAGER_STATUS_DEAD = 2;
+const VILLAGER_STATUS_UNKOWN = 0;
+
 class Villager
 {
 	constructor(x, y, health = 100, defense = 75)
@@ -7,6 +11,7 @@ class Villager
 		this.imageDirection = 0;
 		this.direction = [random(width), random(height)];
 		this.health = health;
+		this.status = VILLAGER_STATUS_ALIVE;
 		this.index = 0;
 		this.isBurried = false;
 		this.id = Math.random() * this.posX * this.posY;

--- a/script/warrior.js
+++ b/script/warrior.js
@@ -35,12 +35,13 @@ class Warrior extends Villager
 
 	die()
 	{
+		this.status = VILLAGER_STATUS_DEAD;
 		this.barrack.warriorDied();
 	}
 	
 	update() 
 	{
-		if (this.health <= 0) 
+		if (this.health <= 0 && this.status != VILLAGER_STATUS_DEAD) 
 		{
 			this.die();
 			this.displayText = "DEAD WARRIOR";
@@ -52,11 +53,12 @@ class Warrior extends Villager
 			this.state = 3;
 		}
 
-		if (this.sword_durable <= 0) 
+		if (this.sword_durable <= 0 && this.state !== 1) 
 		{
 			this.state = 0;	
 		}
 
+		// Move toward blacksmith
 		if (this.state == 0) 
 		{
 			this.inBuilding = false;
@@ -71,6 +73,7 @@ class Warrior extends Villager
 			}
 		}
 
+		// Pick up a sword from the blacksmith
 		if (this.state == 1) 
 		{
 			this.inBuilding = true;
@@ -82,6 +85,7 @@ class Warrior extends Villager
 			}
 		}
 		
+		// Move randomly and attack an enemy if one is found
 		if (this.state == 2) 
 		{
 			this.inBuilding = false;
@@ -94,6 +98,7 @@ class Warrior extends Villager
 			this.animate();
 		}
 		
+		// Head to hospital
 		if (this.state == 3) 
 		{
 			this.inBuilding = false;
@@ -108,9 +113,9 @@ class Warrior extends Villager
 			}
 			//console.log('not at hospital yet', this.hospital);
 			this.move(this.hospital.posX, this.hospital.posY);
-			this.animate();
 		}
 
+		// Heal at hospital
 		if (this.state == 4) 
 		{
 			this.inBuilding = true;
@@ -121,7 +126,7 @@ class Warrior extends Villager
                 this.health = 100;
 				this.hospital.releasePatient();
 				this.setDefaultDispalyText();
-                this.state = 0;
+                this.state = 2; // Go back to moving randomly from here
             }
 		}
 	}


### PR DESCRIPTION
Every cycle once a warrior died it kept removing 1 from warriors and deployed from barracks so it went crazy negative and had essentially infinite capacity for new warriors. I added a base status to the villager class for alive / dead.

Next phases is to make warriors spawning dependent on food. One step at a time though.